### PR TITLE
实现用户新增 email、删除 email、设置主 email、验证 email 等 API #40

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,16 +4,16 @@ from rest_framework.routers import DefaultRouter
 from rest_framework_jwt.views import refresh_jwt_token
 
 from posts.views import PostViewSet
-from tags.views import TagViewSet
 from replies.api.views import ReplyViewSet
-from users.views import UserViewSets
-from users.views import ConfirmEmailView
+from tags.views import TagViewSet
+from users.views import ConfirmEmailView, EmailAddressViewSet, UserViewSets
 
 router = DefaultRouter()
 router.register(r'posts', PostViewSet)
 router.register(r'tags', TagViewSet)
 router.register(r'replies', ReplyViewSet)
 router.register(r'users', UserViewSets)
+router.register(r'users/email', EmailAddressViewSet,base_name='email')
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,7 +14,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from allauth.account.views import email_verification_sent
-
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
@@ -26,14 +25,8 @@ from posts.views import PostViewSet
 from replies.api.views import ReplyViewSet
 from tags.views import TagViewSet
 from users.views import (
-    ConfirmEmailView,
-    GitHubLogin,
-    LoginViewCustom,
-    RegisterViewCustom,
-    UserViewSets,
-)
-from tags.views import TagViewSet
-from users.views import ConfirmEmailView, EmailAddressViewSet, UserViewSets
+    ConfirmEmailView, EmailAddressViewSet, GitHubLogin, LoginViewCustom, RegisterViewCustom,
+    UserViewSets)
 
 router = DefaultRouter()
 router.register(r'posts', PostViewSet)

--- a/users/permissions.py
+++ b/users/permissions.py
@@ -1,0 +1,23 @@
+from rest_framework import permissions
+
+
+class IsVerified(permissions.BasePermission):
+    """
+    设置主 email 时必须为已验证的 email
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if obj.verified:
+            return True
+        return False
+
+
+class NotPrimary(permissions.BasePermission):
+    """
+    不能删除主 email
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if obj.primary:
+            return False
+        return True

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,7 +1,9 @@
 from allauth.account.adapter import get_adapter
+from allauth.account.models import EmailAddress
 from allauth.account.utils import setup_user_email
 from rest_auth.registration.serializers import RegisterSerializer
 from rest_framework import serializers
+from rest_framework.fields import CurrentUserDefault
 
 from .models import User
 from .utils import get_ip_address_from_request
@@ -73,3 +75,15 @@ class UserRegistrationSerializer(RegisterSerializer):
         self.custom_signup(request, user)
         setup_user_email(request, user, [])
         return user
+
+
+class EmailAddressSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EmailAddress
+        fields = (
+            'user',
+            'email',
+            'verified',
+            'primary',
+        )
+        read_only_fields = ('user', 'verified', 'primary')

--- a/users/tests/unit_tests/test_views.py
+++ b/users/tests/unit_tests/test_views.py
@@ -1,3 +1,4 @@
+from allauth.account.models import EmailAddress
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.utils.timezone import now, timedelta
@@ -122,3 +123,153 @@ class UserViewSetTestCase(test.APITestCase):
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Record.objects.count(), 2)
+
+
+class EmailAddressViewSetTestCase(test.APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='test',
+            email='test@test.com',
+            password='test',
+            nickname='test'
+        )
+
+        self.another_user = User.objects.create_user(
+            username='another',
+            email='another@test.com',
+            password='another',
+            nickname='another'
+        )
+
+        self.email = EmailAddress.objects.create(
+            user=self.user,
+            email=self.user.email,
+            verified=True,
+            primary=True
+        )
+
+        self.unverified_email = EmailAddress.objects.create(
+            user=self.user,
+            email='unverified@test.com',
+            verified=False,
+            primary=False
+        )
+
+        self.another_user_email = EmailAddress.objects.create(
+            user=self.another_user,
+            email=self.another_user.email,
+            verified=True,
+            primary=True
+        )
+
+    def test_anonymous_user_cannot_operate_email(self):
+        list_url = reverse('email-list')
+        retrieve_url = reverse('email-detail', kwargs={'pk': self.email.id})
+        set_primary_url = reverse('email-set-primary', kwargs={'pk': self.email.id})
+        reverify_url = reverse('email-reverify', kwargs={'pk': self.email.id})
+
+        response = self.client.get(list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.get(retrieve_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.post(list_url, data={
+            'user': self.user,
+            'email': 'new@email.com',
+            'verified': True,
+            'primary': True
+        })
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.delete(list_url, data={'email': self.user.email})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.post(set_primary_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.get(reverify_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_user_can_get_self_email(self):
+        url = reverse('email-list')
+        self.client.login(username='test', password='test')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(
+            all([ret['user'] == self.user.id for ret in response.data])
+        )
+
+    def test_user_cannnot_get_others_email(self):
+        url = reverse('email-detail', kwargs={'pk': self.another_user_email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_user_can_add_email(self):
+        url = reverse('email-list')
+        self.client.login(username='test', password='test')
+        response = self.client.post(url, data={
+            'user': self.user,
+            'email': 'new@email.com',
+            'verified': True,
+            'primary': True
+        })
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.user.emailaddress_set.count(), 3)
+
+    def test_user_cannot_set_unverified_email_to_primary(self):
+        url = reverse('email-set-primary', kwargs={'pk': self.unverified_email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_can_set_verified_email_to_primary(self):
+        verified_unprimary_email = EmailAddress.objects.create(
+            user=self.user,
+            email='verified_unprimary_email@test.com',
+            verified=True,
+            primary=False
+        )
+        url = reverse('email-set-primary', kwargs={'pk': verified_unprimary_email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # 新的 primary email 设置成功
+        new_primary_email = EmailAddress.objects.get(pk=verified_unprimary_email.id)
+        self.assertTrue(new_primary_email.primary)
+
+        # 旧的 primary email 被设置为非 primary email
+        old_primary_email = EmailAddress.objects.get(pk=self.email.id)
+        self.assertFalse(old_primary_email.primary)
+
+    def test_can_delete_non_primary_email(self):
+        url = reverse('email-detail', kwargs={'pk': self.unverified_email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(self.user.emailaddress_set.count(), 1)
+
+    def test_user_cannot_delete_primary_email(self):
+        url = reverse('email-detail', kwargs={'pk': self.email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.delete(url, data={'email': self.email.email})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.user.emailaddress_set.count(), 2)
+
+    def test_user_cannot_delete_others_email(self):
+        url = reverse('email-detail', kwargs={'pk': self.another_user_email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self.another_user.emailaddress_set.count(), 1)
+
+    def test_user_can_reverify_email(self):
+        url = reverse('email-reverify', kwargs={'pk': self.email.id})
+        self.client.login(username='test', password='test')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/users/views.py
+++ b/users/views.py
@@ -4,7 +4,6 @@ import random
 from allauth.account.views import ConfirmEmailView as AllAuthConfirmEmailView
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from rest_auth.registration.views import LoginView, RegisterView, SocialLoginView
-from rest_framework import permissions, status, viewsets
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
@@ -15,6 +14,7 @@ from balance.api.permissions import IsCurrentUser, OncePerDay
 from balance.api.serializers import BalanceSerializer
 from balance.models import Record
 from replies.api.serializers import FlatReplySerializer
+
 from .models import User
 from .permissions import IsVerified, NotPrimary
 from .serializers import EmailAddressSerializer, UserDetailsSerializer


### PR DESCRIPTION
这个 PR 实现了一系列用户设置 email 的 API。

在 django-allauth 中，允许用户绑定多个 email，可以设置一个主 email，新增绑定的 email 必须邮箱激活验证，可以解除绑定的 email。

API 如下：

### 获取用户的 Email 列表：
GET /users/email/

返回：`
```
HTTP 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

[
    {
        "user": 2,
        "email": "z@df.cc",
        "verified": true,
        "primary": false
    },
    {
        "user": 2,
        "email": "zmrenwu@1563.ccc",
        "verified": true,
        "primary": true
    }
]
```

### 绑定新的 Email 和验证
绑定：POST /users/email/
终端传递：
```
{
    "email": "email@163.com"
}
```
返回：
HTTP 201 Created
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "user": 2,
    "email": "zmrenw@588999.cdas",
    "verified": false,
    "primary": false
}

绑定成功会自动发一封激活邮件到绑定的 email，如果用户没有收到，可以重新发送：
重发验证邮件：GET /users/email/<email_id>/reverify/

成功返回 200

### 设置主 email
用户可以将绑定的且验证成功的任何一个邮箱设置为主 email：

POST /users/email/<email_id>/set_primary/

返回：
```
POST /users/email/1/set_primary/
HTTP 201 Created
Allow: POST, OPTIONS
Content-Type: application/json
Vary: Accept
```

### 删除非主 email

DELETE /users/email/<email_id>/

返回：
```
HTTP 204 No Content
Allow: GET, DELETE, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept
```



