### PR TITLE
完善回复的 serializer，修改 post 的部分接口

### DIFF
--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -10,9 +10,7 @@ class IndexPostListSerializer(serializers.HyperlinkedModelSerializer):
     """
     首页帖子列表序列化器
     """
-    # TODO: 等待userserializer的定义，返回更详细的author信息
     author = serializers.SerializerMethodField()
-
     reply_count = serializers.SerializerMethodField()
     tags = TagSerializer(many=True, read_only=True)
     latest_reply_time = serializers.SerializerMethodField()
@@ -34,15 +32,13 @@ class IndexPostListSerializer(serializers.HyperlinkedModelSerializer):
             'reply_count',
         )
 
-    def get_author(self, value):
-        data = {}
-        data['id'] = value.author.id
-        try:
-            data['mugshot'] = value.author.mugshot.url
-        except ValueError:
-            data['mugshot'] = None
-        data['nickname'] = value.author.nickname
-        return data
+    def get_author(self, obj):
+        author = obj.author
+        return {
+            'id': author.id,
+            'mugshot': author.mugshot.url,
+            'nickname': author.nickname,
+        }
 
     def get_reply_count(self, value):
         """
@@ -66,7 +62,6 @@ class PopularPostSerializer(serializers.HyperlinkedModelSerializer):
     """
     热门帖子序列化器
     """
-    # TODO: 返回user_url 需要实现了user-deail
     author = serializers.SerializerMethodField()
 
     class Meta:
@@ -78,11 +73,13 @@ class PopularPostSerializer(serializers.HyperlinkedModelSerializer):
             'author',
         )
 
-    def get_author(self, value):
-        data = {}
-        data['id'] = value.author.id
-        data['mugshot'] = value.author.mugshot.url
-        return data
+    def get_author(self, obj):
+        author = obj.author
+        return {
+            'id': author.id,
+            'mugshot': author.mugshot.url,
+            'nickname': author.nickname,
+        }
 
 
 class PostDetailSerializer(IndexPostListSerializer):
@@ -90,7 +87,6 @@ class PostDetailSerializer(IndexPostListSerializer):
     用来显示帖子详情，已经用来创建、修改帖子的序列化器
     """
     author = serializers.SerializerMethodField()
-    replies = serializers.SerializerMethodField()
     participants_count = serializers.SerializerMethodField()
     content_type = serializers.SerializerMethodField()
 
@@ -108,7 +104,6 @@ class PostDetailSerializer(IndexPostListSerializer):
             'tags',
             'reply_count',
             'participants_count',
-            'replies'
         )
 
     def get_content_type(self, value):

--- a/posts/views.py
+++ b/posts/views.py
@@ -154,5 +154,10 @@ class PostViewSet(viewsets.ModelViewSet):
     def replies(self, request, pk=None):
         post = self.get_object()
         replies = post.replies.filter(is_public=True, is_removed=False)
+        page = self.paginate_queryset(replies)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
         serializer = self.get_serializer(replies, many=True)
         return Response(serializer.data)

--- a/replies/models.py
+++ b/replies/models.py
@@ -1,5 +1,6 @@
-from django.db import models
+from actstream.models import Follow
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 from django_comments.abstracts import CommentAbstractModel
 from mptt.models import MPTTModel, TreeForeignKey
 
@@ -24,6 +25,9 @@ class Reply(MPTTModel, CommentAbstractModel):
         """
         return self.get_descendants().order_by('submit_date')
 
+    def descendants_count(self):
+        return self.get_descendant_count()
+
     @property
     def ctype(self):
         return ContentType.objects.get_for_model(self)
@@ -31,3 +35,7 @@ class Reply(MPTTModel, CommentAbstractModel):
     @property
     def ctype_id(self):
         return self.ctype.id
+
+    @property
+    def like_count(self):
+        return Follow.objects.for_object(self, flag='like').count()

--- a/replies/serializers.py
+++ b/replies/serializers.py
@@ -11,11 +11,13 @@ class FlatReplySerializer(serializers.ModelSerializer):
     """
     post = serializers.SerializerMethodField()
     user = serializers.SerializerMethodField()
+    parent_user = serializers.SerializerMethodField()
 
     class Meta:
         model = Reply
         fields = (
             'user',
+            'parent_user',
             'post',
             'submit_date',
             'comment',
@@ -31,6 +33,17 @@ class FlatReplySerializer(serializers.ModelSerializer):
 
     def get_user(self, obj):
         user = obj.user
+        return {
+            'id': user.id,
+            'nickname': user.nickname,
+            'mugshot': user.mugshot.url,
+        }
+
+    def get_parent_user(self, obj):
+        parent = obj.parent
+        if not parent:
+            return None
+        user = parent.user
         return {
             'id': user.id,
             'nickname': user.nickname,

--- a/replies/serializers.py
+++ b/replies/serializers.py
@@ -9,46 +9,33 @@ class FlatReplySerializer(serializers.ModelSerializer):
     返回一个扁平化的按发表时间倒序排序的 reply 列表，无视其层级关系。
     适合用在 user 详情页面的个人回复列表中。
     """
-    # TODO: 应该返回被回复帖子的 hyperlink，用户点击帖子标题后就跳转到帖子页面的回复处
-    # TODO: 应该返父回复用户的 hyperlink，用户点击昵称后跳转到该用户的详情页
-    # TODO：等帖子和用户的 API 确定后再修改
-    post_title = serializers.SerializerMethodField()
-    parent_user = serializers.SerializerMethodField()
-
-    # TODO: 统一到 user 中，等待 UserSerializer 的定义
-    # 获取用户头像报 Unicode 编码错误
-    # user_mugshot = serializers.SerializerMethodField()
-    user_nickname = serializers.SerializerMethodField()
-    like_count = serializers.SerializerMethodField()
+    post = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
 
     class Meta:
         model = Reply
         fields = (
-            # 'user_mugshot',
-            'user_nickname',
-            'post_title',
+            'user',
+            'post',
             'submit_date',
             'comment',
-            'parent_user',
             'like_count',
         )
 
-    def get_post_title(self, obj):
-        return obj.content_object.title
+    def get_post(self, obj):
+        post = obj.content_object
+        return {
+            'id': post.id,
+            'title': post.title,
+        }
 
-    def get_parent_user(self, obj):
-        if obj.parent:
-            return obj.parent.user.nickname
-        return None
-
-    def get_user_mugshot(self, obj):
-        return obj.user.mugshot
-
-    def get_user_nickname(self, obj):
-        return obj.user.nickname
-
-    def get_like_count(self, obj):
-        return Follow.objects.for_object(obj, flag='like').count()
+    def get_user(self, obj):
+        user = obj.user
+        return {
+            'id': user.id,
+            'nickname': user.nickname,
+            'mugshot': user.mugshot.url,
+        }
 
 
 class ReplyCreationSerializer(serializers.ModelSerializer):
@@ -83,38 +70,28 @@ class TreeRepliesSerializer(serializers.ModelSerializer):
     这个 Serializer 适合用于帖子详情页的 reply 列表。
     """
     descendants = FlatReplySerializer(many=True)
-    num_descendants = serializers.SerializerMethodField()
-
-    # TODO: 统一到 user 中，等待 UserSerializer 的定义
-    # user_mugshot = serializers.SerializerMethodField()
-    user_nickname = serializers.SerializerMethodField()
-    like_count = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
 
     class Meta:
         model = Reply
         fields = (
             'content_type',
             'object_pk',
-            # 'user_mugshot',
-            'user_nickname',
             'comment',
             'submit_date',
             'like_count',
-            'num_descendants',
+            'user',
             'descendants',
+            'descendants_count',
         )
 
-    def get_num_descendants(self, obj):
-        return obj.descendants().count()
-
-    def get_user_mugshot(self, obj):
-        return obj.user.mugshot
-
-    def get_user_nickname(self, obj):
-        return obj.user.nickname
-
-    def get_like_count(self, obj):
-        return Follow.objects.for_object(obj, flag='like').count()
+    def get_user(self, obj):
+        user = obj.user
+        return {
+            'id': user.id,
+            'nickname': user.nickname,
+            'mugshot': user.mugshot.url,
+        }
 
 
 class FollowSerializer(serializers.ModelSerializer):

--- a/replies/serializers.py
+++ b/replies/serializers.py
@@ -42,6 +42,8 @@ class ReplyCreationSerializer(serializers.ModelSerializer):
     """
     仅用于 reply 的创建
     """
+    parent_user = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
 
     class Meta:
         model = Reply
@@ -55,6 +57,8 @@ class ReplyCreationSerializer(serializers.ModelSerializer):
             'ip_address',
             'is_public',
             'is_removed',
+            'user',
+            'parent_user',
         )
         read_only_fields = (
             'submit_date',
@@ -62,6 +66,25 @@ class ReplyCreationSerializer(serializers.ModelSerializer):
             'is_public',
             'is_removed',
         )
+
+    def get_parent_user(self, obj):
+        parent = obj.parent
+        if not parent:
+            return None
+        user = parent.user
+        return {
+            'id': user.id,
+            'nickname': user.nickname,
+            'mugshot': user.mugshot.url,
+        }
+
+    def get_user(self, obj):
+        user = obj.user
+        return {
+            'id': user.id,
+            'nickname': user.nickname,
+            'mugshot': user.mugshot.url,
+        }
 
 
 class TreeRepliesSerializer(serializers.ModelSerializer):

--- a/users/tests/unit_tests/test_views.py
+++ b/users/tests/unit_tests/test_views.py
@@ -65,7 +65,7 @@ class UserViewSetTestCase(test.APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.data,
+            response.data['data'],
             FlatReplySerializer(
                 self.user.reply_comments.filter(is_public=True, is_removed=False),
                 many=True
@@ -148,7 +148,7 @@ class UserViewSetTestCase(test.APITestCase):
         url = reverse('user-posts', kwargs={'pk': self.user.id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 3)
+        self.assertEqual(len(response.data['data']), 3)
 
     def test_user_can_only_get_self_hidden_posts(self):
         Post.objects.create(
@@ -174,7 +174,7 @@ class UserViewSetTestCase(test.APITestCase):
 
         self.client.login(username='test', password='test')
         response = self.client.get(url, {'hidden': 'true'})
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['data']), 1)
 
         other_url = reverse('user-posts', kwargs={'pk': self.another_user.id})
         response = self.client.get(other_url, {'hidden': 'true'})

--- a/users/views.py
+++ b/users/views.py
@@ -71,7 +71,7 @@ class UserViewSets(viewsets.GenericViewSet):
     @action(
         methods=['post'],
         detail=True,
-        permission_classes=[permissions.IsAuthenticated, OncePerDay, IsCurrentUser]
+        permission_classes=[permissions.IsAuthenticated, OncePerDay, IsCurrentUser],
     )
     def checkin(self, request, pk=None):
         user = self.get_object()


### PR DESCRIPTION
1. 重构了 reply 的 serializer 定义，让返回的数据更加规整。
2. 重构了 post 的 serializer，让返回的数据更加规整。
3. 去除了在 post 详情中直接获取全部回复的代码，改用额外接口获取。
4. 对用户的帖子、帖子的回复进行分页。